### PR TITLE
feat: player name management

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,13 +2,18 @@ import random
 import string
 import uuid
 
-from pydantic import BaseModel, Field
-from typing import Optional, List
+from pydantic import BaseModel, Field, BeforeValidator
+from typing import Optional, List, Annotated
+
+
+def sanitize_name(name):
+    name = name.strip()
+    return name[:16] if len(name) > 16 else name
 
 
 class Player(BaseModel):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    name: str
+    name: Annotated[str, BeforeValidator(sanitize_name)]
     role: Optional[str] = None
     dedupe: Optional[int] = 0
 
@@ -28,11 +33,11 @@ class Lobby(BaseModel):
 
 
 class CreateLobbyRequest(BaseModel):
-    playerName: str
+    playerName: Annotated[str, BeforeValidator(sanitize_name)]
 
 
 class CheckLobbyRequest(BaseModel):
-    playerName: str
+    playerName: Annotated[str, BeforeValidator(sanitize_name)]
 
 
 class CreateLobbyResponse(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,7 @@ class Player(BaseModel):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     name: str
     role: Optional[str] = None
+    dedupe: Optional[int] = 0
 
 
 class Lobby(BaseModel):
@@ -24,6 +25,14 @@ class Lobby(BaseModel):
     location: Optional[str] = None
     start_time: Optional[int] = None
     duration: int = Field(default=480)  # seconds
+
+
+class CreateLobbyRequest(BaseModel):
+    playerName: str
+
+
+class CheckLobbyRequest(BaseModel):
+    playerName: str
 
 
 class CreateLobbyResponse(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -38,8 +38,10 @@ class CheckLobbyRequest(BaseModel):
 class CreateLobbyResponse(BaseModel):
     lobbyId: str
     playerId: str
+    playerName: str
 
 
 class CheckLobbyResponse(BaseModel):
     playerId: str
     lobbyId: str
+    playerName: str

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -8,7 +8,6 @@ from app.models import (
 )
 import uuid
 
-from app.utils import sanitize_name
 
 router = APIRouter()
 
@@ -26,9 +25,8 @@ def create_lobby(request: Request, body: CreateLobbyRequest):
     request.app.database["Lobby"].insert_one(lobby.model_dump(by_alias=True))
     print(f"Created a lobby with code {lobby.id}")
 
-    sanitized_name = sanitize_name(body.playerName)
     return CreateLobbyResponse(
-        lobbyId=lobby.id, playerId=lobby.creator, playerName=sanitized_name
+        lobbyId=lobby.id, playerId=lobby.creator, playerName=body.playerName
     )
 
 
@@ -47,7 +45,6 @@ def check_lobby(lobby_id: str, request: Request, body: CheckLobbyRequest):
             detail=f"Lobby with code {lobby_id} not found",
         )
 
-    sanitized_name = sanitize_name(body.playerName)
     return CheckLobbyResponse(
-        lobbyId=lobby_id, playerId=uuid.uuid4().hex, playerName=sanitized_name
+        lobbyId=lobby_id, playerId=uuid.uuid4().hex, playerName=body.playerName
     )

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,11 @@
 from fastapi import APIRouter, HTTPException, Request, status
-from app.models import CheckLobbyResponse, CreateLobbyResponse, Lobby
+from app.models import (
+    CheckLobbyResponse,
+    CreateLobbyResponse,
+    Lobby,
+    CreateLobbyRequest,
+    CheckLobbyRequest,
+)
 import uuid
 
 from app.utils import sanitize_name
@@ -21,7 +27,9 @@ def create_lobby(request: Request, body: CreateLobbyRequest):
     print(f"Created a lobby with code {lobby.id}")
 
     sanitized_name = sanitize_name(body.playerName)
-    return CreateLobbyResponse(lobbyId=lobby.id, playerId=lobby.creator)
+    return CreateLobbyResponse(
+        lobbyId=lobby.id, playerId=lobby.creator, playerName=sanitized_name
+    )
 
 
 @router.post(
@@ -40,4 +48,6 @@ def check_lobby(lobby_id: str, request: Request, body: CheckLobbyRequest):
         )
 
     sanitized_name = sanitize_name(body.playerName)
-    return CheckLobbyResponse(lobbyId=lobby_id, playerId=uuid.uuid4().hex)
+    return CheckLobbyResponse(
+        lobbyId=lobby_id, playerId=uuid.uuid4().hex, playerName=sanitized_name
+    )

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, WebSocket
 from starlette.websockets import WebSocketDisconnect
 
-from models import Player
+from app.models import Player
+from app.utils import sanitize_name
 
 
 class PlayerMetadata:
@@ -35,23 +36,28 @@ class ConnectionManager:
         database = connection.app.database["Lobby"]
 
         # todo: lobby id does not exist
-        if (lobby := lobby_database.find_one({"code": lobby_id})) is None:
+        if (lobby := database.find_one({"_id": lobby_id})) is None:
             print(f"Lobby with code {lobby_id} not found")
             return
 
+        player_name = sanitize_name(player_name)
         dedupe_num = 0
         for player in lobby["players"]:
-            if player.name == sanitized_name:
-                dedupe_num = max(player.dedupe + 1, dedupe_num)
+            if player["name"] == player_name:
+                dedupe_num = max(player["dedupe"] + 1, dedupe_num)
 
-        player = Player(id=player_id, name=player_name, dedupe=dedupe_num).model_dump(by_alias=True)
+        player = Player(id=player_id, name=player_name, dedupe=dedupe_num).model_dump(
+            by_alias=True
+        )
         database.update_one({"_id": lobby_id}, {"$push": {"players": player}})
 
         if lobby_id not in self.lobby_to_connections:
             self.lobby_to_connections[lobby_id] = []
 
         await self.broadcast_event(
-            lobby_id, "PLAYER_JOIN", {"playerId": player_id, "playerName": player_name}
+            lobby_id,
+            "PLAYER_JOIN",
+            {"playerId": player_id, "playerName": player_name, "dedupe": dedupe_num},
         )
 
         self.lobby_to_connections[lobby_id].append(connection)
@@ -81,6 +87,45 @@ class ConnectionManager:
             },
         )
 
+    async def handle_player_rename(self, connection: WebSocket, player_name: str):
+        database = connection.app.database["Lobby"]
+        metadata = self.connection_to_metadata.get(connection)
+        player_id = metadata.player_id
+        lobby_id = metadata.lobby_id
+
+        lobby = database.find_one({"_id": lobby_id})
+
+        player_name = sanitize_name(player_name)
+        player_by_id = next(
+            (player for player in lobby["players"] if player["id"] == player_id), None
+        )
+
+        if player_by_id["name"] != player_name:
+            dedupe_num = 0
+            for player in lobby["players"]:
+                if player["name"] == player_name:
+                    dedupe_num = max(player["dedupe"] + 1, dedupe_num)
+
+            database.update_one(
+                {"_id": lobby_id, "players.id": player_id},
+                {
+                    "$set": {
+                        "players.$.name": player_name,
+                        "players.$.dedupe": dedupe_num,
+                    }
+                },
+            )
+
+            await self.broadcast_event(
+                lobby_id,
+                "PLAYER_RENAME",
+                {
+                    "playerId": player_id,
+                    "playerName": player_name,
+                    "dedupe": dedupe_num,
+                },
+            )
+
 
 websocket_router = APIRouter()
 manager = ConnectionManager()
@@ -101,6 +146,11 @@ async def websocket_endpoint(websocket: WebSocket):
                         websocket,
                         event_data["lobbyId"],
                         event_data["playerId"],
+                        event_data["playerName"],
+                    )
+                case "PLAYER_RENAME":
+                    await manager.handle_player_rename(
+                        websocket,
                         event_data["playerName"],
                     )
                 case _:

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from app.models import Player
-from app.utils import sanitize_name
 
 
 class PlayerMetadata:
@@ -40,7 +39,6 @@ class ConnectionManager:
             print(f"Lobby with code {lobby_id} not found")
             return
 
-        player_name = sanitize_name(player_name)
         dedupe_num = 0
         for player in lobby["players"]:
             if player["name"] == player_name:
@@ -95,7 +93,6 @@ class ConnectionManager:
 
         lobby = database.find_one({"_id": lobby_id})
 
-        player_name = sanitize_name(player_name)
         player_by_id = next(
             (player for player in lobby["players"] if player["id"] == player_id), None
         )

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,5 +1,3 @@
-import re
-
 def sanitize_name(name):
-    sanitized_name = re.sub(r'[^A-Za-zÀ-ÿ]+', '', name).strip()
-    return sanitized_name[:16] if len(sanitized_name) > 16 else sanitized_name
+    name = name.strip()
+    return name[:16] if len(name) > 16 else name

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,3 +1,0 @@
-def sanitize_name(name):
-    name = name.strip()
-    return name[:16] if len(name) > 16 else name

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,5 @@
+import re
+
+def sanitize_name(name):
+    sanitized_name = re.sub(r'[^A-Za-zÀ-ÿ]+', '', name).strip()
+    return sanitized_name[:16] if len(sanitized_name) > 16 else sanitized_name

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -3,6 +3,6 @@
   "tabWidth": 2,
   "printWidth": 100,
   "singleQuote": true,
-  "trailingComma": "none",
+  "trailingComma": "all",
   "jsxBracketSameLine": true
 }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,10 @@
 ### Requirements:
+
 - npm ([installation instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm/))
 - `npm i` to install dependencies
 
 ### Run dev server:
+
 ```
 npm run dev
 ```

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,14 +14,14 @@ export default [
   eslintPluginPrettierRecommended,
   {
     rules: {
-      'react/react-in-jsx-scope': 'off'
-    }
+      'react/react-in-jsx-scope': 'off',
+    },
   },
   {
     settings: {
       react: {
-        version: 'detect'
-      }
-    }
-  }
+        version: 'detect',
+      },
+    },
+  },
 ];

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,5 +13,5 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/:lobbyId" element={<LobbyPage />} />
       </Routes>
     </BrowserRouter>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/frontend/src/molecules/PlayerListItem.tsx
+++ b/frontend/src/molecules/PlayerListItem.tsx
@@ -1,22 +1,66 @@
-import { IconButton, ListItem, ListItemIcon, ListItemText } from '@mui/material';
+import {
+  Box,
+  Button,
+  IconButton,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Modal,
+  TextField,
+} from '@mui/material';
 import { Close, Edit, Face, FaceRetouchingNatural } from '@mui/icons-material';
+import { useState } from 'react';
+import { Player } from '../utils/models.ts';
+import { modalStyle } from '../utils/utils.ts';
 
 interface PlayerListItemProps {
-  playerName: string;
-  isCreator: boolean;
-  canEdit: boolean;
-  canKick: boolean;
+  player: Player;
+  rename: (newName: string) => void;
+  creator: string;
 }
 
-function PlayerListItem({ playerName, isCreator, canEdit, canKick }: PlayerListItemProps) {
+function PlayerListItem({ player, rename, creator }: PlayerListItemProps) {
+  const [showModal, setShowModal] = useState(false);
+  const [newName, setNewName] = useState(player.name);
+
+  const canEdit = player.id === localStorage.getItem('playerId');
+  const canKick = creator === localStorage.getItem('playerId') && !canEdit;
+  const dedupeString = (player.dedupe ?? 0 > 0) ? `(${[player.dedupe]})` : '';
+
+  const onRename = () => {
+    rename(newName);
+    setShowModal(false);
+  };
+
   return (
     <ListItem
       secondaryAction={
-        <IconButton edge="end">{canEdit ? <Edit /> : canKick && <Close />}</IconButton>
+        (canEdit || canKick) && (
+          <IconButton edge="end" onClick={() => setShowModal(true)}>
+            {canEdit && <Edit />}
+            {canKick && <Close />}
+          </IconButton>
+        )
       }
     >
-      <ListItemIcon>{isCreator ? <FaceRetouchingNatural /> : <Face />}</ListItemIcon>
-      <ListItemText primary={playerName} />
+      <ListItemIcon>{player.id === creator ? <FaceRetouchingNatural /> : <Face />}</ListItemIcon>
+      <ListItemText primary={`${player.name} ${dedupeString}`} />
+      <Modal open={showModal} onClose={() => setShowModal(false)}>
+        <Box sx={modalStyle}>
+          <TextField
+            label="Change name"
+            defaultValue={player.name}
+            slotProps={{ htmlInput: { maxLength: 16 } }}
+            autoComplete="off"
+            fullWidth
+            onChange={(text) => setNewName(text.target.value.trim())}
+          />
+          <Button onClick={() => setShowModal(false)}>Cancel</Button>
+          <Button variant="contained" onClick={onRename} disabled={newName === player.name}>
+            Submit
+          </Button>
+        </Box>
+      </Modal>
     </ListItem>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,20 +2,7 @@ import { useState } from 'react';
 import { Box, Button, Modal, Stack, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import spyfallLogo from '../assets/react.svg';
-import { LOBBY_CODE_LENGTH, post, sanitizeLobbyCode } from '../utils/utils.ts';
-
-const lobbyCodeModalStyle = {
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: 300,
-  bgcolor: 'background.paper',
-  color: 'black',
-  borderRadius: '10px',
-  p: 4,
-  textAlign: 'center',
-};
+import { LOBBY_CODE_LENGTH, modalStyle, post, sanitizeLobbyCode } from '../utils/utils.ts';
 
 function HomePage() {
   const navigate = useNavigate();
@@ -43,7 +30,7 @@ function HomePage() {
   // If valid, join lobby with that code
   const handleCodeChange = (code: string) => {
     code = sanitizeLobbyCode(code);
-    if (code.length != LOBBY_CODE_LENGTH) {
+    if (code.length < LOBBY_CODE_LENGTH) {
       setCodeHelperText('Code is 4 characters');
       return;
     }
@@ -92,7 +79,7 @@ function HomePage() {
         </Button>
       </Stack>
       <Modal open={showModal} onClose={() => setShowModal(false)}>
-        <Box sx={lobbyCodeModalStyle}>
+        <Box sx={modalStyle}>
           <Typography variant="h4" component="label" gutterBottom>
             Enter Lobby Code
           </Typography>

--- a/frontend/src/pages/LobbyPage.tsx
+++ b/frontend/src/pages/LobbyPage.tsx
@@ -32,10 +32,9 @@ function LobbyPage() {
         {gameState.players.map((player) => (
           <PlayerListItem
             key={player.id}
-            playerName={player.name}
-            isCreator={player.id === gameState.creator}
-            canEdit={player.id === localStorage.getItem('playerId')}
-            canKick={localStorage.getItem('playerId') === gameState.creator}
+            player={player}
+            rename={sendEvent.playerRenameEvent}
+            creator={gameState.creator}
           />
         ))}
       </List>

--- a/frontend/src/utils/models.ts
+++ b/frontend/src/utils/models.ts
@@ -1,0 +1,15 @@
+export interface Player {
+  id: string;
+  name: string;
+  dedupe?: number;
+}
+
+interface CreateLobbyRequest {
+  playerName: string;
+}
+
+interface CheckLobbyRequest {
+  playerName: string;
+}
+
+export type RequestBody = CreateLobbyRequest | CheckLobbyRequest;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,0 +1,29 @@
+export const LOBBY_CODE_LENGTH = 4;
+
+export const sanitizeLobbyCode = (code: string) => {
+  return code
+    .trim()
+    .replace(/[^0-9a-z]+/gi, '')
+    .toUpperCase()
+    .substring(0, LOBBY_CODE_LENGTH);
+};
+
+interface CreateLobbyRequest {
+  playerName: string;
+}
+
+interface CheckLobbyRequest {
+  playerName: string;
+}
+
+type RequestBody = CreateLobbyRequest | CheckLobbyRequest;
+
+export const post = (body: RequestBody) => {
+  return {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  };
+};

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { RequestBody } from './models.ts';
+
 export const LOBBY_CODE_LENGTH = 4;
 
 export const sanitizeLobbyCode = (code: string) => {
@@ -8,16 +10,6 @@ export const sanitizeLobbyCode = (code: string) => {
     .substring(0, LOBBY_CODE_LENGTH);
 };
 
-interface CreateLobbyRequest {
-  playerName: string;
-}
-
-interface CheckLobbyRequest {
-  playerName: string;
-}
-
-type RequestBody = CreateLobbyRequest | CheckLobbyRequest;
-
 export const post = (body: RequestBody) => {
   return {
     method: 'POST',
@@ -26,4 +18,17 @@ export const post = (body: RequestBody) => {
     },
     body: JSON.stringify(body),
   };
+};
+
+export const modalStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 300,
+  bgcolor: 'background.paper',
+  color: 'black',
+  borderRadius: '10px',
+  p: 4,
+  textAlign: 'center',
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
 });


### PR DESCRIPTION
- slight refactor in frontend to support renaming and name validation
- added ability for players to rename themselves from the lobby screen
- persisted player names for future visits (name field is autopopulated)
- added `dedupe` to the player model to differentiate players with the same name
    - this looks like `player` and `player (1)` on the frontend
- trimmed and validated player names (max 16 characters, no trailing whitespace)
- trimmed and validated lobby code (4 characters, all uppercase)
- added trailing commas to our prettier config 