### PR TITLE
fix: mitigate backend cold start

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Request, Response, status
 from app.models import (
     CheckLobbyResponse,
     CreateLobbyResponse,
@@ -11,10 +11,19 @@ from app.models import (
 router = APIRouter()
 
 
+@router.get(
+    "/",
+    description="Dummy endpoint to mitigate cold start",
+    status_code=status.HTTP_200_OK,
+)
+def default():
+    return Response(status_code=status.HTTP_200_OK)
+
+
 @router.post(
     "/lobby",
     tags=["lobby"],
-    response_description="Create a new lobby",
+    description="Create a new lobby",
     status_code=status.HTTP_201_CREATED,
     response_model=CreateLobbyResponse,
 )
@@ -32,7 +41,7 @@ def create_lobby(request: Request, body: CreateLobbyRequest):
 @router.post(
     "/lobby/{lobby_id}",
     tags=["lobby"],
-    response_description="Check if lobby exists",
+    description="Check if lobby exists",
     status_code=status.HTTP_200_OK,
     response_model=CheckLobbyResponse,
 )

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Button, Modal, Stack, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import spyfallLogo from '../assets/logo.svg';
@@ -17,6 +17,10 @@ function HomePage() {
   const [showModal, setShowModal] = useState(false);
   const [disableCodeField, setDisableCodeField] = useState(false);
   const [codeHelperText, setCodeHelperText] = useState('');
+
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/`, { method: 'GET' });
+  }, []);
 
   const handleCreateLobby = () => {
     fetch(


### PR DESCRIPTION
added an empty api request on home page load so it's not as jarring of a wait when making the first backend api call (create/check lobby) since it takes ~3 seconds to start the backend if stopped. 