### PR TITLE
feat: handle reconnects

### DIFF
--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -71,6 +71,10 @@ class ConnectionManager:
                 )
         # handle player join
         else:
+            # game in progress
+            if lobby.start_time is not None:
+                await self.send_event(connection, "GO_HOME", {})
+                return
             # handle player name collision
             dedupe_num = 0
             for player in lobby.players:
@@ -258,31 +262,38 @@ async def websocket_endpoint(websocket: WebSocket):
     await manager.connect(websocket)
     try:
         while True:
-            event = await websocket.receive_json()
-            event_type = event["type"]
-            event_data = event["data"]
+            try:
+                event = await websocket.receive_json()
+                event_type = event["type"]
+                event_data = event["data"]
 
-            match event_type:
-                case "PLAYER_JOIN":
-                    await manager.handle_player_join(
-                        websocket,
-                        event_data["lobbyId"],
-                        event_data["playerId"],
-                        event_data["playerName"],
-                    )
-                case "PLAYER_RENAME":
-                    await manager.handle_player_rename(
-                        websocket,
-                        event_data["playerName"],
-                    )
-                case "KICK_PLAYER":
-                    await manager.handle_player_kick(websocket, event_data["playerId"])
-                case "START_GAME":
-                    await manager.handle_start_game(websocket)
-                case "RESET_GAME":
-                    await manager.handle_reset_game(websocket)
-                case _:
-                    print(f"Received event with unhandled type: {event}")
+                match event_type:
+                    case "PLAYER_JOIN":
+                        await manager.handle_player_join(
+                            websocket,
+                            event_data["lobbyId"],
+                            event_data["playerId"],
+                            event_data["playerName"],
+                        )
+                    case "PLAYER_RENAME":
+                        await manager.handle_player_rename(
+                            websocket,
+                            event_data["playerName"],
+                        )
+                    case "KICK_PLAYER":
+                        await manager.handle_player_kick(
+                            websocket, event_data["playerId"]
+                        )
+                    case "START_GAME":
+                        await manager.handle_start_game(websocket)
+                    case "RESET_GAME":
+                        await manager.handle_reset_game(websocket)
+                    case _:
+                        print(f"Received event with unhandled type: {event}")
+            except json.JSONDecodeError:
+                text = await websocket.receive_text()
+                if text == "PING":
+                    await websocket.send_text("PONG")
 
     except WebSocketDisconnect:
         await manager.handle_player_leave(websocket)

--- a/frontend/src/atoms/StrikeableButton.tsx
+++ b/frontend/src/atoms/StrikeableButton.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react';
 
 interface StrikeableButtonProps {
   text: string;
+  icon?: React.ReactNode;
 }
 
-function StrikeableButton({ text }: StrikeableButtonProps) {
+function StrikeableButton({ text, icon }: StrikeableButtonProps) {
   const [strikethrough, setStrikethrough] = useState<boolean>(false);
   const toggleStrikethrough = () => {
     setStrikethrough((prev) => !prev);
@@ -19,6 +20,7 @@ function StrikeableButton({ text }: StrikeableButtonProps) {
       >
         {text}
       </Typography>
+      {icon}
     </Button>
   );
 }

--- a/frontend/src/molecules/NotesTabs.tsx
+++ b/frontend/src/molecules/NotesTabs.tsx
@@ -39,7 +39,7 @@ function PlayersTab({ players, selected }: PlayersTabProps) {
       <Grid2 container>
         {players.map((player) => {
           return (
-            <Grid2 size={{ xs: 12, sm: 6 }} key={player.name}>
+            <Grid2 size={{ xs: 12, sm: 6 }} sx={{ my: 1 }} key={player.name}>
               <StrikeableButton text={player.name} icon={player.disconnected && <PowerOff />} />
             </Grid2>
           );

--- a/frontend/src/molecules/NotesTabs.tsx
+++ b/frontend/src/molecules/NotesTabs.tsx
@@ -1,6 +1,6 @@
 import { AppBar, Box, Grid2, Stack, Tab, Tabs } from '@mui/material';
 import { SyntheticEvent, useState } from 'react';
-import { AssignmentInd, Place } from '@mui/icons-material';
+import { AssignmentInd, Place, PowerOff } from '@mui/icons-material';
 import { Player } from '../utils/models.ts';
 import StrikeableButton from '../atoms/StrikeableButton.tsx';
 
@@ -40,7 +40,7 @@ function PlayersTab({ players, selected }: PlayersTabProps) {
         {players.map((player) => {
           return (
             <Grid2 size={{ xs: 12, sm: 6 }} key={player.name}>
-              <StrikeableButton text={player.name} />
+              <StrikeableButton text={player.name} icon={player.disconnected && <PowerOff />} />
             </Grid2>
           );
         })}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ function HomePage() {
   return (
     <Stack height="100%" p="2rem" justifyContent="center" alignItems="center">
       <img style={{ width: '100%', maxWidth: '400px' }} src={logo} alt="logo" />
-      <Typography variant="h4" sx={{ mb: 5 }} fontFamily="Playpen Sans">
+      <Typography variant="h3" sx={{ mb: 5 }} fontFamily="Playpen Sans">
         Spyfall
       </Typography>
       <Stack width="100%" maxWidth="400px">

--- a/frontend/src/utils/hooks/useGameStateManager.tsx
+++ b/frontend/src/utils/hooks/useGameStateManager.tsx
@@ -25,7 +25,17 @@ export const useGameStateManager = (navigate: NavigateFunction) => {
     sendJsonMessage,
     lastJsonMessage,
     readyState: socketState,
-  } = useWebSocket(import.meta.env.VITE_WEBSOCKET_URL);
+  } = useWebSocket(import.meta.env.VITE_WEBSOCKET_URL, {
+    shouldReconnect: () => true,
+    reconnectInterval: 3000,
+    heartbeat: {
+      message: 'PING',
+      returnMessage: 'PONG',
+      interval: 10000,
+      timeout: 20000,
+    },
+  });
+
   const [players, setPlayers] = useState<Player[]>([]);
   const [creator, setCreator] = useState<string>('');
   const [location, setLocation] = useState<string>();
@@ -40,7 +50,7 @@ export const useGameStateManager = (navigate: NavigateFunction) => {
     setStartTime(lobby.start_time);
     setDuration(lobby.duration);
 
-    if (localStorage.getItem('playerName') === undefined) {
+    if (localStorage.getItem('playerName') === null) {
       const thisPlayer = lobby.players.find(
         (player) => player.id === localStorage.getItem('playerId'),
       );


### PR DESCRIPTION
gracefully handle reconnects
- phone screen off will auto-reconnect
- attempting to join an in-progress game will fail
  - reconnecting to an in-progress game still works
- disconnected players will be marked with an icon in the player list