### PR TITLE
chore: lobby cleanup and proper logging

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,18 @@
 import os
+from contextlib import asynccontextmanager
 
 import motor.motor_asyncio
 from beanie import init_beanie
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
-from contextlib import asynccontextmanager
+from uvicorn.logging import logging
 
 from app.models import Lobby
 from app.routes import router
 from app.sockets import websocket_router
 
+logger = logging.getLogger("uvicorn")
 
 load_dotenv()
 
@@ -27,9 +29,9 @@ async def lifespan(app: FastAPI):
         database=database,
         document_models=[Lobby],
     )
-    print("Connected to the MongoDB database!")
+    logger.info("Connected to the MongoDB database.")
     yield
-    print("Database shutdown")
+    logger.info("Database shutdown.")
     app.mongodb_client.close()
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -48,7 +48,7 @@ class Lobby(Document):
     create_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Settings:
-        indexes = [IndexModel("create_time", expireAfterSeconds=86400)]  # 1 day
+        indexes = [IndexModel("create_time", expireAfterSeconds=3600)]  # 1 hour
 
 
 class CreateLobbyRequest(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Annotated, List, Optional
 
 from beanie import Document
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, Field
 from pymongo import IndexModel
 
 
@@ -38,8 +38,6 @@ class Lobby(Document):
         letters = string.ascii_letters.replace("I", "")
         numbers = string.digits.replace("0", "")
         return "".join(random.choice(letters + numbers) for _ in range(4)).upper()
-
-    model_config = ConfigDict(json_encoders={datetime: lambda dt: dt.isoformat()})
 
     id: str = Field(default_factory=generate_id)
     creator: str = Field(default_factory=lambda: uuid.uuid4().hex)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,13 +1,16 @@
 from fastapi import APIRouter, HTTPException, Response, status
+from uvicorn.logging import logging
+
 from app.models import (
-    CreateLobbyRequest,
-    CreateLobbyResponse,
     CheckLobbyRequest,
     CheckLobbyResponse,
+    CreateLobbyRequest,
+    CreateLobbyResponse,
     Lobby,
     sanitize_lobby_id,
 )
 
+logger = logging.getLogger("uvicorn")
 
 router = APIRouter()
 
@@ -34,7 +37,7 @@ async def create_lobby(body: CreateLobbyRequest):
         lobby = Lobby(creator=body.playerId)
         if await Lobby.get(lobby.id) is None:
             await lobby.insert()
-            print(f"Created a lobby with code {lobby.id}")
+            logger.info("Created a lobby with code %s.", lobby.id)
             return CreateLobbyResponse(
                 lobbyId=lobby.id, playerId=body.playerId, playerName=body.playerName
             )

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -56,7 +56,7 @@ async def create_lobby(body: CreateLobbyRequest):
 )
 async def check_lobby(lobby_id: str, body: CheckLobbyRequest):
     lobby_id = sanitize_lobby_id(lobby_id)
-    if (await Lobby.get(lobby_id)) is None:
+    if await Lobby.get(lobby_id) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Lobby with code {lobby_id} not found",

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -37,6 +37,12 @@ class ConnectionManager:
         for connection in self.lobby_to_connections[lobby_id]:
             await self.send_event(connection, event_type, data)
 
+    async def get_lobby(self, lobby_id: str):
+        lobby = await Lobby.get(lobby_id)
+        if lobby is None:
+            await self.broadcast_event(lobby_id, "GO_HOME", {})
+        return lobby
+
     async def handle_player_join(
         self, connection: WebSocket, lobby_id: str, player_id: str, player_name: str
     ):
@@ -120,7 +126,7 @@ class ConnectionManager:
         lobby_id = metadata.lobby_id
         self.lobby_to_connections[lobby_id].remove(connection)
 
-        lobby = await Lobby.get(lobby_id)
+        lobby = await self.get_lobby(lobby_id)
         player = next(
             (player for player in lobby.players if player.id == player_id), None
         )
@@ -169,7 +175,7 @@ class ConnectionManager:
         player_id = metadata.player_id
         lobby_id = metadata.lobby_id
 
-        lobby = await Lobby.get(lobby_id)
+        lobby = await self.get_lobby(lobby_id)
 
         player_by_id = next(
             (player for player in lobby.players if player.id == player_id), None
@@ -199,7 +205,7 @@ class ConnectionManager:
         metadata = self.connection_to_metadata.get(connection)
         lobby_id = metadata.lobby_id
 
-        lobby = await Lobby.get(lobby_id)
+        lobby = await self.get_lobby(lobby_id)
         if lobby.creator != metadata.player_id:
             return
 
@@ -212,7 +218,7 @@ class ConnectionManager:
         metadata = self.connection_to_metadata.get(connection)
         lobby_id = metadata.lobby_id
 
-        lobby = await Lobby.get(lobby_id)
+        lobby = await self.get_lobby(lobby_id)
         if len(lobby.players) < 3:
             return
 
@@ -253,7 +259,7 @@ class ConnectionManager:
         metadata = self.connection_to_metadata.get(connection)
         lobby_id = metadata.lobby_id
 
-        lobby = await Lobby.get(lobby_id)
+        lobby = await self.get_lobby(lobby_id)
         lobby.start_time = None
         lobby.location = None
         for player in lobby.players:

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import json
 import random
 import time
@@ -258,6 +259,7 @@ class ConnectionManager:
         for player in lobby.players:
             player.role = None
         lobby.players = [player for player in lobby.players if not player.disconnected]
+        lobby.create_time = datetime.now(timezone.utc)
         await lobby.save()
 
         await self.broadcast_event(

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -108,7 +108,7 @@ class ConnectionManager:
         await self.send_event(
             connection,
             "LOBBY_STATE",
-            {"lobby": lobby.model_dump()},
+            {"lobby": lobby.model_dump(mode="json")},
         )
 
     async def handle_player_leave(self, connection: WebSocket):
@@ -245,7 +245,7 @@ class ConnectionManager:
         await self.broadcast_event(
             lobby_id,
             "LOBBY_STATE",
-            {"lobby": lobby.model_dump()},
+            {"lobby": lobby.model_dump(mode="json")},
         )
 
     async def handle_reset_game(self, connection: WebSocket):
@@ -263,7 +263,7 @@ class ConnectionManager:
         await self.broadcast_event(
             lobby_id,
             "LOBBY_STATE",
-            {"lobby": lobby.model_dump()},
+            {"lobby": lobby.model_dump(mode="json")},
         )
 
 

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -4,8 +4,11 @@ import time
 
 from fastapi import APIRouter, WebSocket
 from starlette.websockets import WebSocketDisconnect
+from uvicorn.logging import logging
 
-from app.models import Player, Lobby, sanitize_name, sanitize_lobby_id
+from app.models import Lobby, Player, sanitize_lobby_id, sanitize_name
+
+logger = logging.getLogger("uvicorn")
 
 
 class PlayerMetadata:


### PR DESCRIPTION
adds a TTL index so mongo automatically cleans up lobbies after 24 hours

also swaps out the existing print statements for proper logging

should be merged after #27 