### PR TITLE
feat: how to play

### DIFF
--- a/frontend/src/atoms/CloseDialogButton.tsx
+++ b/frontend/src/atoms/CloseDialogButton.tsx
@@ -1,0 +1,24 @@
+import { IconButton } from '@mui/material';
+import { Close } from '@mui/icons-material';
+
+interface CloseDialogButtonProps {
+  onClick: () => void;
+}
+
+function CloseDialogButton({ onClick }: CloseDialogButtonProps) {
+  return (
+    <IconButton
+      onClick={onClick}
+      sx={{
+        position: 'absolute',
+        right: 12,
+        top: 12,
+        fill: 'currentcolor',
+      }}
+    >
+      <Close />
+    </IconButton>
+  );
+}
+
+export default CloseDialogButton;

--- a/frontend/src/molecules/HowToPlayDialog.tsx
+++ b/frontend/src/molecules/HowToPlayDialog.tsx
@@ -1,0 +1,62 @@
+import { Dialog, DialogContent, DialogTitle, Stack, Typography, Box, Button } from '@mui/material';
+import CloseDialogButton from '../atoms/CloseDialogButton.tsx';
+
+interface HowToPlayDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function HowToPlayDialog({ open, onClose }: HowToPlayDialogProps) {
+  const LineBreak = () => <Box component="span" display="block" mb={1} />;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        How to Play
+        <CloseDialogButton onClick={onClose} />
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={1}>
+          <Typography variant="body2">
+            Spyfall is a game of deduction and deception.
+            <LineBreak />
+            Each round, a location is chosen and revealed to everyone except the spy.
+            <LineBreak />
+            The spy&apos;s goal is to guess the location while everyone else tries to identify the
+            spy.
+          </Typography>
+          <LineBreak />
+          <Typography variant="subtitle1">[Setup]</Typography>
+          <Typography variant="body2">
+            • Create a lobby and share the code with your friends
+            <LineBreak />
+            • The host can start the game with 3-8 players
+            <LineBreak />• The spy and location will be chosen at random
+          </Typography>
+          <LineBreak />
+          <Typography variant="subtitle1">[Gameplay]</Typography>
+          <Typography variant="body2">
+            • Players take turns asking each other questions
+            <LineBreak />
+            • The spy should try to blend in by being vague
+            <LineBreak />• Other players should be specific but not too obvious
+          </Typography>
+          <LineBreak />
+          <Typography variant="subtitle1">[Winning]</Typography>
+          <Typography variant="body2">
+            • The spy wins by correctly guessing the location
+            <LineBreak />
+            • Other players win by voting out the spy
+            <LineBreak />• The game ends when time runs out or a vote is called
+          </Typography>
+          <LineBreak />
+          <Button variant="contained" onClick={onClose}>
+            Close
+          </Button>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default HowToPlayDialog;

--- a/frontend/src/molecules/LobbyCodeDialog.tsx
+++ b/frontend/src/molecules/LobbyCodeDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogTitle, TextField } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { LOBBY_CODE_LENGTH, post, sanitizeLobbyCode, uuid } from '../utils/utils.ts';
+import CloseDialogButton from '../atoms/CloseDialogButton.tsx';
 
 interface LobbyCodeDialogProps {
   open: boolean;
@@ -47,7 +48,10 @@ function LobbyCodeDialog({ open, onClose, playerName }: LobbyCodeDialogProps) {
 
   return (
     <Dialog open={open} onClose={onDialogClose}>
-      <DialogTitle>Enter Lobby Code</DialogTitle>
+      <DialogTitle>
+        Enter Lobby Code
+        <CloseDialogButton onClick={onClose} />
+      </DialogTitle>
       <DialogContent sx={{ py: 0 }}>
         <TextField
           fullWidth

--- a/frontend/src/molecules/PlayerRenameDialog.tsx
+++ b/frontend/src/molecules/PlayerRenameDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import { PLAYER_NAME_LENGTH } from '../utils/utils.ts';
-
+import CloseDialogButton from '../atoms/CloseDialogButton.tsx';
 interface PlayerRenameDialogProps {
   open: boolean;
   onClose: () => void;
@@ -31,7 +31,10 @@ function PlayerRenameDialog({
 
   return (
     <Dialog open={open} onClose={onClose}>
-      <DialogTitle>Edit Name</DialogTitle>
+      <DialogTitle>
+        Edit Name
+        <CloseDialogButton onClick={onClose} />
+      </DialogTitle>
       <DialogContent>
         <TextField
           value={newName}

--- a/frontend/src/molecules/PlayerRenameDialog.tsx
+++ b/frontend/src/molecules/PlayerRenameDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from 'react';
 import { PLAYER_NAME_LENGTH } from '../utils/utils.ts';
 import CloseDialogButton from '../atoms/CloseDialogButton.tsx';
+
 interface PlayerRenameDialogProps {
   open: boolean;
   onClose: () => void;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { Button, Stack, TextField, Typography } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import logo from '../assets/logo.svg';
 import { PLAYER_NAME_LENGTH, post, uuid } from '../utils/utils.ts';
+import HowToPlayDialog from '../molecules/HowToPlayDialog.tsx';
 import LobbyCodeDialog from '../molecules/LobbyCodeDialog.tsx';
 import ErrorToast from '../molecules/ErrorToast.tsx';
 
@@ -10,6 +11,7 @@ function HomePage() {
   const navigate = useNavigate();
   const location = useLocation();
   const [name, setName] = useState(localStorage.getItem('playerName') || '');
+  const [showHowToPlayModal, setShowHowToPlayModal] = useState(false);
   const [showLobbyCodeModal, setShowLobbyCodeModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [showError, setShowError] = useState(false);
@@ -79,6 +81,9 @@ function HomePage() {
           <Button variant="contained" disabled={!name} onClick={handleJoinLobby}>
             Join Lobby
           </Button>
+          <Button variant="text" onClick={() => setShowHowToPlayModal(true)} size="small">
+            how to play
+          </Button>
         </Stack>
       </Stack>
       <LobbyCodeDialog
@@ -86,6 +91,7 @@ function HomePage() {
         onClose={() => setShowLobbyCodeModal(false)}
         playerName={name}
       />
+      <HowToPlayDialog open={showHowToPlayModal} onClose={() => setShowHowToPlayModal(false)} />
       <ErrorToast open={showError} onClose={() => setShowError(false)} message={errorMessage} />
     </Stack>
   );


### PR DESCRIPTION
adds a "how to play" dialog that shows gameplay instructions

also adds a (shared) close button to all dialogs